### PR TITLE
Storing data as bytes instead of converting to hex

### DIFF
--- a/src/BLE_catcher/BLE_catcher.ino
+++ b/src/BLE_catcher/BLE_catcher.ino
@@ -23,7 +23,7 @@ const char * beaconFile = "/beacons.txt";
 deque<String> seenBeacons;
 int maxBeacons = 250;
 
-void writeBeaconToFile(String beacon);
+void writeBeaconToFile(uint8_t* beacon, size_t len);
 
 class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
     void onResult(BLEAdvertisedDevice advertisedDevice) {
@@ -32,20 +32,19 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
 
         uint8_t* payload = advertisedDevice.getPayload();
         size_t len = advertisedDevice.getPayloadLength();
-        
+
+        // TODO: change string-deque to uint8_t-deque, transformation to hex is not necessary anymore here
         std::stringstream stream;
         stream << std::hex << std::setfill('0');
-        
-        // only last 20 bytes of interest; for 31 bytes frame, skip leading 11 bytes; for 28 bytes frame, skip leading 8 bytes
         for (size_t i = len - 20; i < len; i++) {
           stream << std::hex << std::setw(2) << (unsigned int) payload[i];
         }
-
         std::string beacon = stream.str();
-        cout << "Beacon: " << beacon.c_str() << endl;
+        cout << "Logged beacon: " << beacon.c_str() << endl;
 
         if (std::find(seenBeacons.begin(), seenBeacons.end(), beacon.c_str()) == seenBeacons.end()) {
-          writeBeaconToFile(beacon.c_str());
+          // only last 20 bytes of interest; for 31 bytes frame, skip leading 11 bytes; for 28 bytes frame, skip leading 8 bytes
+          writeBeaconToFile(payload + (len - 20), 20);
           seenBeacons.push_front(beacon.c_str());
           if(seenBeacons.size() >= maxBeacons) {
             seenBeacons.pop_back();
@@ -109,19 +108,25 @@ void loop() {
   delay(25000);
 }
 
-void writeBeaconToFile(String beacon) {
+void writeBeaconToFile(uint8_t * beacon, size_t len) {
   // seems to write in pages of 251 bytes length
   if (SPIFFS.totalBytes() - SPIFFS.usedBytes() > 256) {
-    Serial.printf("Used Bytes: %d\n", SPIFFS.usedBytes());
     File file = SPIFFS.open(beaconFile, FILE_APPEND);
     if (file) {
-      Serial.print("Writing to file: ");
-      Serial.print(beacon);
-      Serial.printf(";%d\n", esp_timer_get_time() / 1000000);
-      file.print(beacon);
-      file.printf(";%d\n", esp_timer_get_time() / 1000000);
+      uint64_t currentTime = esp_timer_get_time() / 1000000;
+      // 3 bytes can represent 194 days as seconds, this should be enough in our case :)
+      uint8_t timeArray[] = {(currentTime >> 16), (currentTime >> 8), currentTime};
+
+      for (size_t i = 0; i < len; i++) {
+        file.write(beacon[i]);
+      }
+      for (size_t j = 0; j < sizeof(timeArray); j++) {
+        file.write(timeArray[j]);
+      }
     }
     file.close();
+    cout << "New beacon written to file." << endl;
+    Serial.printf("Used Bytes: %d\n", SPIFFS.usedBytes());
   } else {
     scan = false;
   }
@@ -137,7 +142,18 @@ void readFile(fs::FS &fs, const char * path){
   Serial.println("Reading logged frames:");
       File file = SPIFFS.open(path, FILE_READ);
         while(file.available()){
-          Serial.write(file.read());
+          uint8_t beacon[20];
+          uint8_t timeArray[3];
+          file.read(beacon, sizeof(beacon));
+          file.read(timeArray, sizeof(timeArray));
+          
+          std::stringstream stream;
+          stream << std::hex << std::setfill('0');
+          for (size_t i = 0; i < sizeof(beacon); i++) {
+            stream << std::hex << std::setw(2) << (unsigned int) beacon[i];
+          }
+          uint32_t currentTime = (uint32_t) timeArray[0] << 16 | (uint16_t) timeArray[1] << 8 | timeArray[2];
+          cout << stream.str() << ";" << currentTime << endl;
         }
         file.close();
  }


### PR DESCRIPTION
Reading from file was also adapted to new write function.
TODO: adjust deque accordingly to work on uint8_t* instead of Strings.

Seems to work in its current state. Maybe we should ensure that any frames with less than 20 bytes (which *should* never occur) are definitely not processed, since that could cause trouble in the current version. 